### PR TITLE
feat: Improve 3D animation realism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@react-three/drei": "^10.6.1",
         "@react-three/fiber": "^9.3.0",
+        "@react-three/postprocessing": "^3.0.4",
         "@reactuses/core": "^6.0.5",
         "@tanstack/react-query": "^5.82.0",
         "@tanstack/react-table": "^8.21.3",
@@ -4284,6 +4285,32 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
+    },
+    "node_modules/@react-three/postprocessing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
+      "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "maath": "^0.6.0",
+        "n8ao": "^1.9.4",
+        "postprocessing": "^6.36.6"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19.0",
+        "three": ">= 0.156.0"
+      }
+    },
+    "node_modules/@react-three/postprocessing/node_modules/maath": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
+      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
+      }
     },
     "node_modules/@reactuses/core": {
       "version": "6.0.5",
@@ -11053,6 +11080,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/n8ao": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.1.tgz",
+      "integrity": "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "postprocessing": ">=6.30.0",
+        "three": ">=0.137"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -11771,6 +11808,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postprocessing": {
+      "version": "6.37.7",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.37.7.tgz",
+      "integrity": "sha512-3mXzCyhHQvw6cMQKzvHUzQVsy21yC3PZMIeH7KUjx+EVqLWRFPnARh4DEnnFJ+tE08mmIHrrN7UtxVR1Gxbokw==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "three": ">= 0.157.0 < 0.180.0"
       }
     },
     "node_modules/potpack": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@react-three/drei": "^10.6.1",
     "@react-three/fiber": "^9.3.0",
+    "@react-three/postprocessing": "^3.0.4",
     "@reactuses/core": "^6.0.5",
     "@tanstack/react-query": "^5.82.0",
     "@tanstack/react-table": "^8.21.3",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/sheet"
 import { Button } from "@/components/ui/button"
 import { Settings, Play, Pause, RotateCcw } from "lucide-react"
+import { EffectComposer, Bloom } from '@react-three/postprocessing'
+import { KernelSize } from 'postprocessing'
 
 // Safe clipboard function with error handling
 const safeCopyToClipboard = async (text: string): Promise<boolean> => {
@@ -271,6 +273,16 @@ export default function Home() {
               maxDistance={30}
               minDistance={5}
             />
+
+            {/* Post-processing */}
+            <EffectComposer>
+              <Bloom
+                intensity={0.4}
+                luminanceThreshold={0.1}
+                luminanceSmoothing={0.8}
+                kernelSize={KernelSize.MEDIUM}
+              />
+            </EffectComposer>
           </Suspense>
         </Canvas>
       </div>

--- a/src/components/apparatus/BiefeldBrownApparatus.tsx
+++ b/src/components/apparatus/BiefeldBrownApparatus.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Mesh, Group } from 'three'
+import { RoundedBox } from '@react-three/drei'
 
 interface BiefeldBrownApparatusProps {
   constructionProgress: number
@@ -102,14 +103,16 @@ export function BiefeldBrownApparatus({
         position={[1, 0, 0]}
         rotation={[0, 0, Math.PI / 6]}
       >
-        <boxGeometry args={[0.1, 3, 2]} />
-        <meshStandardMaterial
-          color="#ff4444"
-          metalness={0.8}
-          roughness={0.2}
-          emissive="#ff0000"
-          emissiveIntensity={0}
-        />
+        <RoundedBox args={[0.1, 3, 2]} radius={0.02} smoothness={4}>
+          <meshStandardMaterial
+            color="#aa2222"
+            metalness={0.9}
+            roughness={0.3}
+            emissive="#ff0000"
+            emissiveIntensity={0}
+            toneMapped={false}
+          />
+        </RoundedBox>
       </mesh>
 
       {/* Dielectric material */}
@@ -117,14 +120,17 @@ export function BiefeldBrownApparatus({
         ref={dielectricRef}
         position={[0, 0, 0]}
       >
-        <boxGeometry args={[0.3, 2.8, 1.8]} />
-        <meshStandardMaterial
-          color="#4444ff"
-          transparent
-          opacity={0.6}
-          roughness={0.9}
-          metalness={0.1}
-        />
+        <RoundedBox args={[0.3, 2.8, 1.8]} radius={0.05} smoothness={4}>
+          <meshPhysicalMaterial
+            color="#88aaff"
+            metalness={0.1}
+            roughness={0.1}
+            transmission={1.0}
+            thickness={1.0}
+            transparent
+            opacity={0.3}
+          />
+        </RoundedBox>
       </mesh>
 
       {/* Negative plate (trailing) */}
@@ -133,14 +139,16 @@ export function BiefeldBrownApparatus({
         position={[-1, 0, 0]}
         rotation={[0, 0, -Math.PI / 6]}
       >
-        <boxGeometry args={[0.1, 3, 2]} />
-        <meshStandardMaterial
-          color="#4444ff"
-          metalness={0.8}
-          roughness={0.2}
-          emissive="#0000ff"
-          emissiveIntensity={0}
-        />
+        <RoundedBox args={[0.1, 3, 2]} radius={0.02} smoothness={4}>
+          <meshStandardMaterial
+            color="#2222aa"
+            metalness={0.9}
+            roughness={0.3}
+            emissive="#0000ff"
+            emissiveIntensity={0}
+            toneMapped={false}
+          />
+        </RoundedBox>
       </mesh>
 
       {/* High voltage connections */}
@@ -149,13 +157,13 @@ export function BiefeldBrownApparatus({
           {/* Positive connection */}
           <mesh position={[1.5, 1.5, 0]}>
             <cylinderGeometry args={[0.02, 0.02, 1]} />
-            <meshStandardMaterial color="#ffaa00" metalness={0.9} />
+            <meshStandardMaterial color="#b87333" metalness={0.9} roughness={0.2} />
           </mesh>
           
           {/* Negative connection */}
           <mesh position={[-1.5, -1.5, 0]}>
             <cylinderGeometry args={[0.02, 0.02, 1]} />
-            <meshStandardMaterial color="#00aaff" metalness={0.9} />
+            <meshStandardMaterial color="#c0c0c0" metalness={0.9} roughness={0.2} />
           </mesh>
         </>
       )}


### PR DESCRIPTION
This commit enhances the realism of the 3D animations in the R.A.I.N. Lab by:

1.  **Adding a Bloom Post-Processing Effect:** Integrated `@react-three/postprocessing` to add a bloom effect to the entire scene. This gives emissive materials a more natural and vibrant glow, significantly improving the visual quality of the lighting.

2.  **Enhancing Materials:** The materials of the `BiefeldBrownApparatus` have been updated to be more physically plausible. The metal plates now have a more realistic metallic finish, and the dielectric component uses a `meshPhysicalMaterial` with transmission to simulate a glass-like appearance.

3.  **Refining Geometry:** The primitive `boxGeometry` for the apparatus components has been replaced with `RoundedBox` geometry from `@react-three/drei`. This adds subtle bevels to the edges of the models, making them appear more detailed and less like basic shapes.